### PR TITLE
fix: support proto descriptors without source info included

### DIFF
--- a/pkg/proto/options.go
+++ b/pkg/proto/options.go
@@ -100,12 +100,17 @@ func GetDescriptionOrComment(name NameWithSourceResolver, description Descriptio
 		return description.GetDescription()
 	}
 
+	srcInfo := name.SourceCodeInfo()
+	if srcInfo == nil {
+		return ""
+	}
+
 	builder := &strings.Builder{}
-	for _, comment := range name.SourceCodeInfo().LeadingDetachedComments() {
+	for _, comment := range srcInfo.LeadingDetachedComments() {
 		builder.WriteString(comment)
 	}
-	builder.WriteString(name.SourceCodeInfo().LeadingComments())
-	builder.WriteString(name.SourceCodeInfo().TrailingComments())
+	builder.WriteString(srcInfo.LeadingComments())
+	builder.WriteString(srcInfo.TrailingComments())
 	comment := strings.TrimSpace(strings.Trim(builder.String(), "\n"))
 
 	if comment != "" {
@@ -113,6 +118,7 @@ func GetDescriptionOrComment(name NameWithSourceResolver, description Descriptio
 	}
 	return ""
 }
+
 func GetEntrypointMessage(pluginOptions *PluginOptions, fileOptions *FileOptions) string {
 	if fileOptions != nil && fileOptions.GetEntrypointMessage() != "" {
 		return fileOptions.GetEntrypointMessage()


### PR DESCRIPTION
When proto descriptors are not compiled with `--include_source_info` this tool panics when attempting to get comments.

Panic output:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x69921a]

goroutine 1 [running]:
github.com/pubg/protoc-gen-jsonschema/pkg/proto.GetDescriptionOrComment({0x7e7ba6be7c78, 0xc00021f7a0}, {0x804a60?, 0x0?})
        /home/bweston/workspace/pkg/mod/github.com/pubg/protoc-gen-jsonschema@v0.4.1/pkg/proto/options.go:104 +0x9a
github.com/pubg/protoc-gen-jsonschema/pkg/modules.buildFromMessage(0x0, {0x80e3d0, 0xc00021f7a0}, 0x0)
        /home/bweston/workspace/pkg/mod/github.com/pubg/protoc-gen-jsonschema@v0.4.1/pkg/modules/1_middleend_generator.go:18 +0xf0
github.com/pubg/protoc-gen-jsonschema/pkg/modules.(*MiddleendVisitor).VisitMessage(0xc0002189c0, {0x80e3d0, 0xc00021f7a0})
        /home/bweston/workspace/pkg/mod/github.com/pubg/protoc-gen-jsonschema@v0.4.1/pkg/modules/1_middleend_visitor.go:41 +0xe6
github.com/lyft/protoc-gen-star/v2.(*msg).accept(0xc00021f7a0, {0x808e10?, 0xc0002189c0?})
        /home/bweston/workspace/pkg/mod/github.com/lyft/protoc-gen-star/v2@v2.0.3/message.go:227 +0x42
github.com/lyft/protoc-gen-star/v2.(*file).accept(0xc00020b200, {0x808e10?, 0xc0002189c0?})
        /home/bweston/workspace/pkg/mod/github.com/lyft/protoc-gen-star/v2@v2.0.3/file.go:208 +0x132
github.com/lyft/protoc-gen-star/v2.(*pkg).accept(0xc0002181b0, {0x808e10?, 0xc0002189c0?})
        /home/bweston/workspace/pkg/mod/github.com/lyft/protoc-gen-star/v2@v2.0.3/package.go:43 +0xc8
github.com/lyft/protoc-gen-star/v2.Walk(...)
        /home/bweston/workspace/pkg/mod/github.com/lyft/protoc-gen-star/v2@v2.0.3/node.go:27
github.com/pubg/protoc-gen-jsonschema/pkg/modules.(*Module).Execute(0xc000016660, 0xc000218000, 0xc000218030)
        /home/bweston/workspace/pkg/mod/github.com/pubg/protoc-gen-jsonschema@v0.4.1/pkg/modules/0_module.go:36 +0x2d3
github.com/lyft/protoc-gen-star/v2.(*standardWorkflow).Run(0xc000016640, {0x805ed0, 0xc000208a00})
        /home/bweston/workspace/pkg/mod/github.com/lyft/protoc-gen-star/v2@v2.0.3/workflow.go:61 +0x4af
github.com/lyft/protoc-gen-star/v2.(*onceWorkflow).Run.func1()
        /home/bweston/workspace/pkg/mod/github.com/lyft/protoc-gen-star/v2@v2.0.3/workflow.go:102 +0x2c
sync.(*Once).doSlow(0x682552?, 0xc000016670?)
        /usr/local/go/src/sync/once.go:74 +0xc2
sync.(*Once).Do(...)
        /usr/local/go/src/sync/once.go:65
github.com/lyft/protoc-gen-star/v2.(*onceWorkflow).Run(0xc0000f5730, {0x805ed0?, 0xc000208a00?})
        /home/bweston/workspace/pkg/mod/github.com/lyft/protoc-gen-star/v2@v2.0.3/workflow.go:101 +0x5e
github.com/lyft/protoc-gen-star/v2.(*Generator).Render(0xc0001a8000)
        /home/bweston/workspace/pkg/mod/github.com/lyft/protoc-gen-star/v2@v2.0.3/generator.go:86 +0x49
main.main()
        /home/bweston/workspace/pkg/mod/github.com/pubg/protoc-gen-jsonschema@v0.4.1/main.go:53 +0x21c
--jsonschema_out: protoc-gen-jsonschema: Plugin failed with status code 2.
```