### PR TITLE
fix: Fix bug circular dependent message

### DIFF
--- a/testdata/README.md
+++ b/testdata/README.md
@@ -82,6 +82,8 @@ proto-optional optional이 있다면 required에서 빠지는지 테스트
 
 proto-message message가 object로 잘 전환되는지 테스트
 
+proto-circular-dependent 순환 의존성이 있는 메시지를 잘 전환하는지 테스트
+
 proto-enum enum이 enum으로 잘 전환되는지 테스트
 
 plugin-preserve-field-name-false json_name이 잘 적용되는지 테스트

--- a/testdata/cases/proto-circular-dependent/test.proto
+++ b/testdata/cases/proto-circular-dependent/test.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package tests;
+
+import "jsonschema.proto";
+
+option (pubg.jsonschema.file) = {entrypoint_message: "Values"};
+
+message Values {
+  SelfReference entry = 1;
+}
+
+//message CircularDependentTwoDepth {
+//  CircularDependentTwoDepth0 child = 1;
+//}
+//
+//message CircularDependentTwoDepth0 {
+//  CircularDependentTwoDepth parent = 1;
+//}
+
+message SelfReference {
+  SelfReference self = 1;
+}

--- a/testdata/cases/proto-circular-dependent/test.schema.json
+++ b/testdata/cases/proto-circular-dependent/test.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "#/$defs/.tests.Values",
+  "$defs": {
+    ".tests.Values": {
+      "properties": {
+        "entry": {
+          "$ref": "#/$defs/.tests.Values.entry"
+        }
+      },
+      "type": "object",
+      "required": [
+        "entry"
+      ]
+    },
+    ".tests.Values.entry": {
+      "$ref": "#/$defs/.tests.SelfReference"
+    },
+    ".tests.SelfReference": {
+      "properties": {
+        "self": {
+          "$ref": "#/$defs/.tests.SelfReference.self"
+        }
+      },
+      "type": "object",
+      "required": [
+        "self"
+      ],
+      "description": "message CircularDependentTwoDepth {\n  CircularDependentTwoDepth0 child = 1;\n}\n\nmessage CircularDependentTwoDepth0 {\n  CircularDependentTwoDepth parent = 1;\n}"
+    },
+    ".tests.SelfReference.self": {
+      "$ref": "#/$defs/.tests.SelfReference"
+    }
+  },
+  "type": "object"
+}

--- a/testdata/cases/proto-circular-dependent/test.yaml
+++ b/testdata/cases/proto-circular-dependent/test.yaml
@@ -1,0 +1,11 @@
+name: "proto-circular-dependent"
+description: "Test for circular dependent message in proto file"
+
+inputFiles: ["test.proto"]
+inputParameters: {}
+
+expectResultFiles: ["test.schema.json"]
+expectResultIsNull: false
+expectFail: false
+
+expectedBehaviorDescription: ""


### PR DESCRIPTION
## Problem
There is a bug in the optimization stage of the processing pipeline. The optimization function examines the reference counts of schemas and removes unused messages, which led to issues as it traversed all referenced schemas.

## Solution
Instead of using RefCount, it now checks whether a schema has been visited, preventing duplicate visits to schemas.


Fix: https://github.com/pubg/protoc-gen-jsonschema/issues/8

