### PR TITLE
Add global additional_properties option

### DIFF
--- a/jsonschema.proto
+++ b/jsonschema.proto
@@ -99,6 +99,17 @@ message PluginOptions {
       - --jsonschema_opt=preserve_proto_field_names=false
    */
   bool preserve_proto_field_names = 15;
+
+  /**
+    additional_properties determines the default value of `additionalProperties`
+    for all messages when not specified in MessageOptions.object.
+
+    default: inherit from MessageOptions.object.additional_properties
+    example:
+      - --jsonschema_opt=additional_properties=true
+      - --jsonschema_opt=additional_properties=false
+   */
+  optional bool additional_properties = 16;
 }
 
 enum Draft {

--- a/options.md
+++ b/options.md
@@ -209,6 +209,9 @@ default: false example: - --jsonschema_opt=int64_as_string=true - --jsonschema_o
 | preserve_proto_field_names | [bool](#bool) |  | preserve_proto_field_names is used to determine if output json field names should be identical to the proto field names. Otherwise field names either use the value of the `json_name` field option or they are automatically converted to lowerCamelCase. This default behaviour mirrors the behaviour of Protobuf&#39;s canonical JSON format (ProtoJSON).
 
 default: false example: - --jsonschema_opt=preserve_proto_field_names=true - --jsonschema_opt=preserve_proto_field_names=false |
+| additional_properties | [bool](#bool) | optional | additional_properties determines the default value of `additionalProperties` for all messages.
+
+default: inherit from MessageOptions.object.additional_properties example: - --jsonschema_opt=additional_properties=true - --jsonschema_opt=additional_properties=false |
 
 
 

--- a/pkg/modules/1_middleend_generator.go
+++ b/pkg/modules/1_middleend_generator.go
@@ -19,6 +19,9 @@ func buildFromMessage(pluginOptions *proto.PluginOptions, message pgs.Message, m
 	schema.Properties = jsonschema.NewOrderedSchemaMap()
 
 	fillSchemaByObjectKeywords(schema, mo.GetObject())
+	if schema.AdditionalProperties == nil && pluginOptions.AdditionalProperties != nil {
+		schema.AdditionalProperties = jsonschema.NewBooleanSchema(pluginOptions.GetAdditionalProperties())
+	}
 
 	for _, field := range message.Fields() {
 		// Skip OneOf Block field

--- a/pkg/proto/jsonschema.pb.go
+++ b/pkg/proto/jsonschema.pb.go
@@ -209,7 +209,8 @@ type PluginOptions struct {
 	// example:
 	// - --jsonschema_opt=preserve_proto_field_names=true
 	// - --jsonschema_opt=preserve_proto_field_names=false
-	PreserveProtoFieldNames bool `protobuf:"varint,15,opt,name=preserve_proto_field_names,json=preserveProtoFieldNames,proto3" json:"preserve_proto_field_names,omitempty"`
+	PreserveProtoFieldNames bool  `protobuf:"varint,15,opt,name=preserve_proto_field_names,json=preserveProtoFieldNames,proto3" json:"preserve_proto_field_names,omitempty"`
+	AdditionalProperties    *bool `protobuf:"varint,16,opt,name=additional_properties,json=additionalProperties,proto3,oneof" json:"additional_properties,omitempty"`
 }
 
 func (x *PluginOptions) Reset() {
@@ -296,6 +297,13 @@ func (x *PluginOptions) GetInt64AsString() bool {
 func (x *PluginOptions) GetPreserveProtoFieldNames() bool {
 	if x != nil {
 		return x.PreserveProtoFieldNames
+	}
+	return false
+}
+
+func (x *PluginOptions) GetAdditionalProperties() bool {
+	if x != nil && x.AdditionalProperties != nil {
+		return *x.AdditionalProperties
 	}
 	return false
 }

--- a/pkg/proto/options.go
+++ b/pkg/proto/options.go
@@ -19,6 +19,11 @@ func GetPluginOptions(params pgs.Parameters) *PluginOptions {
 	options.Int64AsString, _ = params.BoolDefault("int64_as_string", false)
 	options.PreserveProtoFieldNames, _ = params.BoolDefault("preserve_proto_field_names", false)
 
+	if _, ok := params["additional_properties"]; ok {
+		val, _ := params.Bool("additional_properties")
+		options.AdditionalProperties = &val
+	}
+
 	// Default Value
 	options.Draft = Draft_Draft202012
 	for draft, index := range Draft_value {


### PR DESCRIPTION
## Summary
- define a plugin-level `additional_properties` option
- parse the option in Go helpers and expose it through generated code
- apply the global default when generating message schemas
- document the new option

## Testing
- `go test ./...`