### PR TITLE
feat: add options to respect ProtoJSON rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # protoc-gen-jsonschema
 
-`protoc-gen-jsonschema` is a plugin that converts `protocol buffer` files into `JSON Schema`. While it primarily focuses on the protobuf standard, it also supports certain non-standard specifications, such as those used by Kubernetes, Node.js, and ArgoCD. Instead of aiming to cover the entire JSON Schema specification, the plugin is specifically designed to translate [ProtoJSON](https://protobuf.dev/programming-guides/json/) specifications. It supports JSON Schema versions `draft-04`, `draft-06`, `draft-07`, `draft-2019-09`, and `draft-2020-12`. as well as support protocol buffer `syntax proto2`, `syntax proto3`.
+`protoc-gen-jsonschema` is a plugin that converts `protocol buffer` files into `JSON Schema`. While it primarily focuses on the protobuf standard, it also supports certain non-standard specifications, such as those used by Kubernetes, Node.js, and ArgoCD. Rather than trying to cover the entire JSON Schema specification, the plugin is intentionally designed to focus on [ProtoJSON](https://protobuf.dev/programming-guides/json/) and the patterns most frequently used in practice. It supports JSON Schema versions `draft-04`, `draft-06`, `draft-07`, `draft-2019-09`, and `draft-2020-12`. as well as support protocol buffer `syntax proto2`, `syntax proto3`.
 
 If you’d like to support another specification, contributions are always welcome! Feel free to submit a PR.
 
@@ -15,7 +15,7 @@ Alternatively, you can download a pre-built binary from [GitHub Release](https:/
 
 # Usage
 
-Refer to the [Plugin Options](#plguin-options) section below for various options available for this plugin.
+Refer to the [Plugin Options](#plugin-options) section below for various options available for this plugin.
 
 ### I'm not sure which options to use
 This plugin provides default options that are ready to use. For testing or generating a basic json-schema file, the following command is sufficient without extra options.

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ protoc --jsonschema_out=. --jsonschema_opt=pretty_json_output=false *.proto
 ```
 
 ### I'd like to comply with the protobuf JSON mapping standard
-By default, this plugin does not comply to the Protobuf standard because most plugins and other JSON libraries do not address integers larger than a 53-bit value. To ensure greater compatibility with other libraries, this plugin converts int64 values to integers instead of strings. However, to comply with the Protobuf standard, int64 values should be converted to strings. Below options will assist you.
+By default, this plugin does not comply with the Protobuf standard because most plugins and other JSON libraries do not address integers larger than a 53-bit value. To ensure greater compatibility with other libraries, this plugin converts int64 values to integers instead of strings. However, to comply with the Protobuf standard, int64 values should be converted to strings. The below options will assist you.
 ```
-protoc --jsonschema_out=. --jsonschema_opt=int64_as_string=true *.proto
+protoc --jsonschema_out=. --jsonschema_opt=respect_protojson_int64=true --jsonschema_opt=respect_protojson_presence=true *.proto
 ```
 
-### I'm not satisfied with the plugin's options. I want to customize every fields
+### I'm not satisfied with the plugin's options. I want to customize every field
 This plugin offers options for fields, messages, and enums. You can utilize these options in the jsonschema.proto file within your proto.
 ```
 cp jsonschema.proto examples/jsonschema.proto
@@ -106,6 +106,10 @@ example:
 
 ### int64_as_string
 ```
+Deprecated: use `respect_protojson_int64` instead. It's has same functionality.
+Just change the name to be more clear.
+
+Old Description:
 int64_as_string determines whether int64 field treat as string.
 Depends on Javascript specification, The JS stores integer to only 53bits.
 So, if you want to use int64 field in JS, you should use string type.
@@ -144,6 +148,30 @@ example:
   - --jsonschema_opt=additional_properties=DefaultTrue
   - --jsonschema_opt=additional_properties=DefaultFalse
   - --jsonschema_opt=additional_properties=DoNothing
+```
+
+### respect_protojson_presence
+```
+This options is used to determine if the plugin should respect the presence of fields
+in the ProtoJSON format. If set to true and fields that does have presence, plugin will
+generate the `required` keyword in the output schema for those fields.
+
+default: false
+example:
+  - --jsonschema_opt=respect_protojson_presence=true
+  - --jsonschema_opt=respect_protojson_presence=false
+```
+
+### respect_protojson_int64
+```
+This options is used to determine if the plugin should respect the int64 fields
+in the ProtoJSON format. If set to true, int64 fields will be treated as strings
+in the output schema, otherwise they will be treated as numbers.
+
+default: false
+example:
+  - --jsonschema_opt=respect_protojson_int64=true
+  - --jsonschema_opt=respect_protojson_int64=false
 ```
 
 ### Protobuf Options

--- a/jsonschema.proto
+++ b/jsonschema.proto
@@ -74,6 +74,10 @@ message PluginOptions {
   bool mandatory_nullable = 13;
 
   /**
+    Deprecated: use `respect_protojson_int64` instead. It's has same functionality.
+    Just change the name to be more clear.
+
+    Old Description:
     int64_as_string determines whether int64 field treat as string.
     Depends on Javascript specification, The JS stores integer to only 53bits.
     So, if you want to use int64 field in JS, you should use string type.
@@ -114,6 +118,30 @@ message PluginOptions {
       - --jsonschema_opt=additional_properties=DoNothing
    */
   PluginAdditionalProperties additional_properties = 16;
+
+  /**
+    This options is used to determine if the plugin should respect the presence of fields
+    in the ProtoJSON format. If set to true and fields that does have presence, plugin will
+    generate the `required` keyword in the output schema for those fields.
+
+    default: false
+    example:
+      - --jsonschema_opt=respect_protojson_presence=true
+      - --jsonschema_opt=respect_protojson_presence=false
+   */
+  bool respect_protojson_presence = 17;
+
+  /**
+    This options is used to determine if the plugin should respect the int64 fields
+    in the ProtoJSON format. If set to true, int64 fields will be treated as strings
+    in the output schema, otherwise they will be treated as numbers.
+
+    default: false
+    example:
+      - --jsonschema_opt=respect_protojson_int64=true
+      - --jsonschema_opt=respect_protojson_int64=false
+   */
+  bool respect_protojson_int64 = 18;
 }
 
 enum PluginAdditionalProperties {

--- a/options.md
+++ b/options.md
@@ -204,7 +204,9 @@ default: Draft202012 example: - --jsonschema_opt=draft=Draft202012 |
 | mandatory_nullable | [bool](#bool) |  | mandatory_nullable determines whether this plugin should treat optional field as nullable. Many programming languages do not differentiate between undefined and null. However, scripting languages like JavaScript and TypeScript can distinguish between them. By default, optional field is treated as nullable and undefined.
 
 default: false example: - --jsonschema_opt=mandatory_nullable=true - --jsonschema_opt=mandatory_nullable=false |
-| int64_as_string | [bool](#bool) |  | int64_as_string determines whether int64 field treat as string. Depends on Javascript specification, The JS stores integer to only 53bits. So, if you want to use int64 field in JS, you should use string type. References:
+| int64_as_string | [bool](#bool) |  | Deprecated: use `respect_protojson_int64` instead. It&#39;s has same functionality. Just change the name to be more clear.
+
+Old Description: int64_as_string determines whether int64 field treat as string. Depends on Javascript specification, The JS stores integer to only 53bits. So, if you want to use int64 field in JS, you should use string type. References:
 
 default: false example: - --jsonschema_opt=int64_as_string=true - --jsonschema_opt=int64_as_string=false |
 | preserve_proto_field_names | [bool](#bool) |  | preserve_proto_field_names is used to determine if output json field names should be identical to the proto field names. Otherwise field names either use the value of the `json_name` field option or they are automatically converted to lowerCamelCase. This default behaviour mirrors the behaviour of Protobuf&#39;s canonical JSON format (ProtoJSON).
@@ -213,6 +215,12 @@ default: false example: - --jsonschema_opt=preserve_proto_field_names=true - --j
 | additional_properties | [PluginAdditionalProperties](#pubg-jsonschema-PluginAdditionalProperties) |  | additional_properties option can control all message&#39;s additional_properties property. If you want set additional properties for all messages, use always_true or always_false. If you want to set additional properties for not defined messages, use default_true or default_false.
 
 default: &#39;DoNothing&#39; example: - --jsonschema_opt=additional_properties=AlwaysTrue - --jsonschema_opt=additional_properties=AlwaysFalse - --jsonschema_opt=additional_properties=DefaultTrue - --jsonschema_opt=additional_properties=DefaultFalse - --jsonschema_opt=additional_properties=DoNothing |
+| respect_protojson_presence | [bool](#bool) |  | This options is used to determine if the plugin should respect the presence of fields in the ProtoJSON format. If set to true and fields that does have presence, plugin will generate the `required` keyword in the output schema for those fields.
+
+default: false example: - --jsonschema_opt=respect_protojson_presence=true - --jsonschema_opt=respect_protojson_presence=false |
+| respect_protojson_int64 | [bool](#bool) |  | This options is used to determine if the plugin should respect the int64 fields in the ProtoJSON format. If set to true, int64 fields will be treated as strings in the output schema, otherwise they will be treated as numbers.
+
+default: false example: - --jsonschema_opt=respect_protojson_int64=true - --jsonschema_opt=respect_protojson_int64=false |
 
 
 

--- a/pkg/proto/jsonschema.pb.go
+++ b/pkg/proto/jsonschema.pb.go
@@ -249,6 +249,10 @@ type PluginOptions struct {
 	// - --jsonschema_opt=mandatory_nullable=false
 	MandatoryNullable bool `protobuf:"varint,13,opt,name=mandatory_nullable,json=mandatoryNullable,proto3" json:"mandatory_nullable,omitempty"`
 	// *
+	// Deprecated: use `respect_protojson_int64` instead. It's has same functionality.
+	// Just change the name to be more clear.
+	//
+	// Old Description:
 	// int64_as_string determines whether int64 field treat as string.
 	// Depends on Javascript specification, The JS stores integer to only 53bits.
 	// So, if you want to use int64 field in JS, you should use string type.
@@ -284,8 +288,28 @@ type PluginOptions struct {
 	// - --jsonschema_opt=additional_properties=DefaultFalse
 	// - --jsonschema_opt=additional_properties=DoNothing
 	AdditionalProperties PluginAdditionalProperties `protobuf:"varint,16,opt,name=additional_properties,json=additionalProperties,proto3,enum=pubg.jsonschema.PluginAdditionalProperties" json:"additional_properties,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// *
+	// This options is used to determine if the plugin should respect the presence of fields
+	// in the ProtoJSON format. If set to true and fields that does have presence, plugin will
+	// generate the `required` keyword in the output schema for those fields.
+	//
+	// default: false
+	// example:
+	// - --jsonschema_opt=respect_protojson_presence=true
+	// - --jsonschema_opt=respect_protojson_presence=false
+	RespectProtojsonPresence bool `protobuf:"varint,17,opt,name=respect_protojson_presence,json=respectProtojsonPresence,proto3" json:"respect_protojson_presence,omitempty"`
+	// *
+	// This options is used to determine if the plugin should respect the int64 fields
+	// in the ProtoJSON format. If set to true, int64 fields will be treated as strings
+	// in the output schema, otherwise they will be treated as numbers.
+	//
+	// default: false
+	// example:
+	// - --jsonschema_opt=respect_protojson_int64=true
+	// - --jsonschema_opt=respect_protojson_int64=false
+	RespectProtojsonInt64 bool `protobuf:"varint,18,opt,name=respect_protojson_int64,json=respectProtojsonInt64,proto3" json:"respect_protojson_int64,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *PluginOptions) Reset() {
@@ -379,6 +403,20 @@ func (x *PluginOptions) GetAdditionalProperties() PluginAdditionalProperties {
 		return x.AdditionalProperties
 	}
 	return PluginAdditionalProperties_DefaultAdditionalProperties
+}
+
+func (x *PluginOptions) GetRespectProtojsonPresence() bool {
+	if x != nil {
+		return x.RespectProtojsonPresence
+	}
+	return false
+}
+
+func (x *PluginOptions) GetRespectProtojsonInt64() bool {
+	if x != nil {
+		return x.RespectProtojsonInt64
+	}
+	return false
 }
 
 type FileOptions struct {
@@ -1135,7 +1173,7 @@ var File_jsonschema_proto protoreflect.FileDescriptor
 
 const file_jsonschema_proto_rawDesc = "" +
 	"\n" +
-	"\x10jsonschema.proto\x12\x0fpubg.jsonschema\x1a google/protobuf/descriptor.proto\x1a\x19google/protobuf/any.proto\"\xe9\x03\n" +
+	"\x10jsonschema.proto\x12\x0fpubg.jsonschema\x1a google/protobuf/descriptor.proto\x1a\x19google/protobuf/any.proto\"\xdf\x04\n" +
 	"\rPluginOptions\x12)\n" +
 	"\x10visibility_level\x18\x01 \x01(\rR\x0fvisibilityLevel\x12-\n" +
 	"\x12entrypoint_message\x18\x02 \x01(\tR\x11entrypointMessage\x12,\n" +
@@ -1146,7 +1184,9 @@ const file_jsonschema_proto_rawDesc = "" +
 	"\x12mandatory_nullable\x18\r \x01(\bR\x11mandatoryNullable\x12&\n" +
 	"\x0fint64_as_string\x18\x0e \x01(\bR\rint64AsString\x12;\n" +
 	"\x1apreserve_proto_field_names\x18\x0f \x01(\bR\x17preserveProtoFieldNames\x12`\n" +
-	"\x15additional_properties\x18\x10 \x01(\x0e2+.pubg.jsonschema.PluginAdditionalPropertiesR\x14additionalProperties\"\x9f\x01\n" +
+	"\x15additional_properties\x18\x10 \x01(\x0e2+.pubg.jsonschema.PluginAdditionalPropertiesR\x14additionalProperties\x12<\n" +
+	"\x1arespect_protojson_presence\x18\x11 \x01(\bR\x18respectProtojsonPresence\x126\n" +
+	"\x17respect_protojson_int64\x18\x12 \x01(\bR\x15respectProtojsonInt64\"\x9f\x01\n" +
 	"\vFileOptions\x12)\n" +
 	"\x10visibility_level\x18\x01 \x01(\rR\x0fvisibilityLevel\x12-\n" +
 	"\x12entrypoint_message\x18\x02 \x01(\tR\x11entrypointMessage\x12\x14\n" +

--- a/pkg/proto/options.go
+++ b/pkg/proto/options.go
@@ -18,9 +18,16 @@ func GetPluginOptions(params pgs.Parameters) *PluginOptions {
 	options.OutputFileSuffix = params.StrDefault("output_file_suffix", ".schema.json")
 	options.PrettyJsonOutput, _ = params.BoolDefault("pretty_json_output", true)
 	options.MandatoryNullable, _ = params.BoolDefault("mandatory_nullable", false)
-	options.Int64AsString, _ = params.BoolDefault("int64_as_string", false)
 	options.PreserveProtoFieldNames, _ = params.BoolDefault("preserve_proto_field_names", false)
+	options.RespectProtojsonPresence, _ = params.BoolDefault("respect_protojson_presence", false)
 
+	if _, ok := params["int64_as_string"]; ok {
+		options.RespectProtojsonInt64, _ = params.Bool("int64_as_string")
+	} else {
+		options.RespectProtojsonInt64, _ = params.BoolDefault("respect_protojson_int64", false)
+	}
+
+	// Default Value
 	options.AdditionalProperties = PluginAdditionalProperties_DoNothing
 	for additionalPropertiesIter, index := range PluginAdditionalProperties_value {
 		if params.Str("additional_properties") == additionalPropertiesIter {


### PR DESCRIPTION
## Resetting the Plugin’s Goal

I initially assumed that this plugin had good support for ProtoJSON. However, as pointed out in #16, the plugin behaves completely differently from ProtoJSON rules when determining whether a field is required or optional.

Fixing the behavior to comply with ProtoJSON is quite simple, but doing so would break backward compatibility. Since I also do not use ProtoJSON directly in my actual work, I decided instead to make a options for ProtoJSON comply mode.

## Two New Plugin Options
- respect_protojson_presence: An option to determine whether a field is required according to the ProtoJSON specification. This is disabled by default.
- respect_protojson_int64: This is essentially a renamed version of the previous int64_as_string option. The old name was overly technical, so I replaced it with a name that explicitly reflects ProtoJSON compliance. The original option will remain available for backward compatibility.