### PR TITLE
feat: make output schema always consist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,5 +57,5 @@ dump-testdata:
     --debug_opt=dump_binary=true \
     --debug_opt=file_binary=request.pb.bin \
     -I ./ \
-    -I ./testdata/cases/jsonschema-object \
-    ./testdata/cases/jsonschema-object/test.proto
+    -I ./testdata/cases/plugin-consist-output \
+    ./testdata/cases/plugin-consist-output/test.proto

--- a/pkg/jsonschema/registry.go
+++ b/pkg/jsonschema/registry.go
@@ -1,5 +1,7 @@
 package jsonschema
 
+import "slices"
+
 type Registry struct {
 	schemasByName SchemaMap
 }
@@ -28,6 +30,17 @@ func (r *Registry) GetKeys() []string {
 
 func (r *Registry) DeleteSchema(id string) {
 	r.schemasByName.Delete(id)
+}
+
+func (r *Registry) SortSchemas() {
+	sortedKeys := slices.Clone(r.GetKeys())
+	slices.Sort(sortedKeys)
+
+	for _, key := range sortedKeys {
+		schema := r.GetSchema(key)
+		r.DeleteSchema(key)
+		r.AddSchema(key, schema)
+	}
 }
 
 func DeepCopyRegistry(registry *Registry) *Registry {

--- a/pkg/modules/0_module.go
+++ b/pkg/modules/0_module.go
@@ -38,10 +38,12 @@ func (m *Module) Execute(targets map[string]pgs.File, packages map[string]pgs.Pa
 	m.Debugf("# of IntermediateSchemas: %d", len(visitor.registry.GetKeys()))
 
 	// Phase: Backend TargetSchemaGenerate
-	var optimizer BackendOptimizer = NewOptimizerImpl(m.pluginOptions)
-	var generator BackendTargetGenerator = NewMultiDraftGenerator(m.pluginOptions)
+	var optimizer BackendOptimizer = NewOptimizerImpl(m.ModuleBase, m.pluginOptions)
+	var generator BackendTargetGenerator = NewMultiDraftGenerator(m.ModuleBase, m.pluginOptions)
 	var serializer BackendSerializer = NewSerializerImpl(m.pluginOptions)
 	m.Push("BackendPhase")
+	visitor.registry.SortSchemas()
+
 	for _, file := range targets {
 		artifact := m.BackendPhase(file, visitor.registry, optimizer, generator, serializer)
 		if artifact != nil {

--- a/pkg/modules/1_frontend_visitor.go
+++ b/pkg/modules/1_frontend_visitor.go
@@ -6,8 +6,8 @@ import (
 	"github.com/pubg/protoc-gen-jsonschema/pkg/proto"
 )
 
-// MiddleendVisitor generate intermediate jsonschema from protobuf
-type MiddleendVisitor struct {
+// FrontendVisitor generate intermediate jsonschema from protobuf
+type FrontendVisitor struct {
 	pgs.Visitor
 
 	debugger pgs.DebuggerCommon
@@ -16,10 +16,10 @@ type MiddleendVisitor struct {
 	pluginOptions *proto.PluginOptions
 }
 
-var _ pgs.Visitor = (*MiddleendVisitor)(nil)
+var _ pgs.Visitor = (*FrontendVisitor)(nil)
 
-func NewVisitor(debugger pgs.DebuggerCommon, pluginOptions *proto.PluginOptions) *MiddleendVisitor {
-	v := &MiddleendVisitor{
+func NewVisitor(debugger pgs.DebuggerCommon, pluginOptions *proto.PluginOptions) *FrontendVisitor {
+	v := &FrontendVisitor{
 		debugger:      debugger,
 		registry:      jsonschema.NewRegistry(),
 		pluginOptions: pluginOptions,
@@ -28,7 +28,7 @@ func NewVisitor(debugger pgs.DebuggerCommon, pluginOptions *proto.PluginOptions)
 	return v
 }
 
-func (v *MiddleendVisitor) VisitMessage(message pgs.Message) (pgs.Visitor, error) {
+func (v *FrontendVisitor) VisitMessage(message pgs.Message) (pgs.Visitor, error) {
 	mo := proto.GetMessageOptions(message)
 	if mo.GetVisibilityLevel() < v.pluginOptions.GetVisibilityLevel() {
 		return nil, nil
@@ -45,7 +45,7 @@ func (v *MiddleendVisitor) VisitMessage(message pgs.Message) (pgs.Visitor, error
 	return v, nil
 }
 
-func (v *MiddleendVisitor) VisitField(field pgs.Field) (pgs.Visitor, error) {
+func (v *FrontendVisitor) VisitField(field pgs.Field) (pgs.Visitor, error) {
 	fo := proto.GetFieldOptions(field)
 	if fo.GetVisibilityLevel() < v.pluginOptions.GetVisibilityLevel() {
 		return nil, nil
@@ -82,7 +82,7 @@ func (v *MiddleendVisitor) VisitField(field pgs.Field) (pgs.Visitor, error) {
 	return v, nil
 }
 
-func (v *MiddleendVisitor) VisitEnum(enum pgs.Enum) (pgs.Visitor, error) {
+func (v *FrontendVisitor) VisitEnum(enum pgs.Enum) (pgs.Visitor, error) {
 	schema, err := buildFromEnum(enum)
 	if err != nil {
 		return nil, err

--- a/pkg/modules/3_backend_target_generator.go
+++ b/pkg/modules/3_backend_target_generator.go
@@ -18,11 +18,12 @@ type BackendTargetGenerator interface {
 var _ BackendTargetGenerator = (*MultiDraftGenerator)(nil)
 
 type MultiDraftGenerator struct {
+	module        *pgs.ModuleBase
 	pluginOptions *proto.PluginOptions
 }
 
-func NewMultiDraftGenerator(pluginOptions *proto.PluginOptions) *MultiDraftGenerator {
-	return &MultiDraftGenerator{pluginOptions: pluginOptions}
+func NewMultiDraftGenerator(module *pgs.ModuleBase, pluginOptions *proto.PluginOptions) *MultiDraftGenerator {
+	return &MultiDraftGenerator{module: module, pluginOptions: pluginOptions}
 }
 
 const draft04Version = "http://json-schema.org/draft-04/schema#"

--- a/testdata/cases/jsonschema-array/test.schema.json
+++ b/testdata/cases/jsonschema-array/test.schema.json
@@ -10,6 +10,29 @@
         "BAZ"
       ]
     },
+    ".tests.MyMessage": {
+      "properties": {
+        "val1": {
+          "$ref": "#/$defs/.tests.MyMessage.val1"
+        },
+        "val2": {
+          "$ref": "#/$defs/.tests.MyMessage.val2"
+        }
+      },
+      "type": "object"
+    },
+    ".tests.MyMessage.val1": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    ".tests.MyMessage.val2": {
+      "items": {
+        "type": "integer"
+      },
+      "type": "array"
+    },
     ".tests.Values": {
       "properties": {
         "val1": {
@@ -43,21 +66,17 @@
       },
       "type": "object"
     },
-    ".tests.Values.val1": {
+    ".tests.Values.enum": {
       "items": {
-        "type": "string"
+        "$ref": "#/$defs/.tests.MyEnum"
       },
       "type": "array"
     },
-    ".tests.Values.val2": {
+    ".tests.Values.message": {
       "items": {
-        "type": "integer",
-        "title": "My Title",
-        "description": "My Description"
+        "$ref": "#/$defs/.tests.MyMessage"
       },
-      "type": "array",
-      "title": "My Title",
-      "description": "My Description"
+      "type": "array"
     },
     ".tests.Values.optioned1": {
       "items": {
@@ -85,40 +104,21 @@
       "minItems": 1,
       "uniqueItems": false
     },
-    ".tests.Values.message": {
-      "items": {
-        "$ref": "#/$defs/.tests.MyMessage"
-      },
-      "type": "array"
-    },
-    ".tests.Values.enum": {
-      "items": {
-        "$ref": "#/$defs/.tests.MyEnum"
-      },
-      "type": "array"
-    },
-    ".tests.MyMessage": {
-      "properties": {
-        "val1": {
-          "$ref": "#/$defs/.tests.MyMessage.val1"
-        },
-        "val2": {
-          "$ref": "#/$defs/.tests.MyMessage.val2"
-        }
-      },
-      "type": "object"
-    },
-    ".tests.MyMessage.val1": {
+    ".tests.Values.val1": {
       "items": {
         "type": "string"
       },
       "type": "array"
     },
-    ".tests.MyMessage.val2": {
+    ".tests.Values.val2": {
       "items": {
-        "type": "integer"
+        "type": "integer",
+        "title": "My Title",
+        "description": "My Description"
       },
-      "type": "array"
+      "type": "array",
+      "title": "My Title",
+      "description": "My Description"
     }
   },
   "type": "object"

--- a/testdata/cases/jsonschema-nullable/test.schema.json
+++ b/testdata/cases/jsonschema-nullable/test.schema.json
@@ -10,6 +10,29 @@
         "BAZ"
       ]
     },
+    ".tests.MyMessage": {
+      "properties": {
+        "val1": {
+          "$ref": "#/$defs/.tests.MyMessage.val1"
+        },
+        "val2": {
+          "$ref": "#/$defs/.tests.MyMessage.val2"
+        }
+      },
+      "type": "object"
+    },
+    ".tests.MyMessage.val1": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    ".tests.MyMessage.val2": {
+      "items": {
+        "type": "integer"
+      },
+      "type": "array"
+    },
     ".tests.Values": {
       "properties": {
         "messages": {
@@ -54,40 +77,17 @@
         "ints"
       ]
     },
-    ".tests.Values.messages": {
-      "$ref": "#/$defs/.tests.MyMessage"
-    },
     ".tests.Values.enums": {
       "$ref": "#/$defs/.tests.MyEnum"
-    },
-    ".tests.Values.strings": {
-      "type": "string"
     },
     ".tests.Values.ints": {
       "type": "integer"
     },
-    ".tests.MyMessage": {
-      "properties": {
-        "val1": {
-          "$ref": "#/$defs/.tests.MyMessage.val1"
-        },
-        "val2": {
-          "$ref": "#/$defs/.tests.MyMessage.val2"
-        }
-      },
-      "type": "object"
+    ".tests.Values.messages": {
+      "$ref": "#/$defs/.tests.MyMessage"
     },
-    ".tests.MyMessage.val1": {
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    ".tests.MyMessage.val2": {
-      "items": {
-        "type": "integer"
-      },
-      "type": "array"
+    ".tests.Values.strings": {
+      "type": "string"
     }
   },
   "type": "object"

--- a/testdata/cases/jsonschema-object/test.schema.json
+++ b/testdata/cases/jsonschema-object/test.schema.json
@@ -2,27 +2,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$ref": "#/$defs/.tests.Values",
   "$defs": {
-    ".tests.Values": {
-      "properties": {
-        "messages": {
-          "$ref": "#/$defs/.tests.Values.messages"
-        },
-        "messages2": {
-          "$ref": "#/$defs/.tests.Values.messages2"
-        }
-      },
-      "type": "object",
-      "required": [
-        "messages",
-        "messages2"
-      ]
-    },
-    ".tests.Values.messages": {
-      "$ref": "#/$defs/.tests.MyMessage"
-    },
-    ".tests.Values.messages2": {
-      "$ref": "#/$defs/.tests.MyMessage2"
-    },
     ".tests.MyMessage": {
       "properties": {
         "val1": {
@@ -76,6 +55,27 @@
         "type": "integer"
       },
       "type": "array"
+    },
+    ".tests.Values": {
+      "properties": {
+        "messages": {
+          "$ref": "#/$defs/.tests.Values.messages"
+        },
+        "messages2": {
+          "$ref": "#/$defs/.tests.Values.messages2"
+        }
+      },
+      "type": "object",
+      "required": [
+        "messages",
+        "messages2"
+      ]
+    },
+    ".tests.Values.messages": {
+      "$ref": "#/$defs/.tests.MyMessage"
+    },
+    ".tests.Values.messages2": {
+      "$ref": "#/$defs/.tests.MyMessage2"
     }
   },
   "type": "object"

--- a/testdata/cases/plugin-additional-properties-always-false/test.schema.json
+++ b/testdata/cases/plugin-additional-properties-always-false/test.schema.json
@@ -2,30 +2,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$ref": "#/$defs/.tests.Values",
   "$defs": {
-    ".tests.Values": {
-      "properties": {
-        "messages": {
-          "$ref": "#/$defs/.tests.Values.messages"
-        },
-        "messages2": {
-          "$ref": "#/$defs/.tests.Values.messages2"
-        }
-      },
-      "additionalProperties": {
-        "not": {}
-      },
-      "type": "object",
-      "required": [
-        "messages",
-        "messages2"
-      ]
-    },
-    ".tests.Values.messages": {
-      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToFalse"
-    },
-    ".tests.Values.messages2": {
-      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToTrue"
-    },
     ".tests.MandatorySetAdditionalPropertiesToFalse": {
       "properties": {
         "val1": {
@@ -81,6 +57,30 @@
         "type": "integer"
       },
       "type": "array"
+    },
+    ".tests.Values": {
+      "properties": {
+        "messages": {
+          "$ref": "#/$defs/.tests.Values.messages"
+        },
+        "messages2": {
+          "$ref": "#/$defs/.tests.Values.messages2"
+        }
+      },
+      "additionalProperties": {
+        "not": {}
+      },
+      "type": "object",
+      "required": [
+        "messages",
+        "messages2"
+      ]
+    },
+    ".tests.Values.messages": {
+      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToFalse"
+    },
+    ".tests.Values.messages2": {
+      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToTrue"
     }
   },
   "type": "object"

--- a/testdata/cases/plugin-additional-properties-always-true/test.schema.json
+++ b/testdata/cases/plugin-additional-properties-always-true/test.schema.json
@@ -2,28 +2,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$ref": "#/$defs/.tests.Values",
   "$defs": {
-    ".tests.Values": {
-      "properties": {
-        "messages": {
-          "$ref": "#/$defs/.tests.Values.messages"
-        },
-        "messages2": {
-          "$ref": "#/$defs/.tests.Values.messages2"
-        }
-      },
-      "additionalProperties": {},
-      "type": "object",
-      "required": [
-        "messages",
-        "messages2"
-      ]
-    },
-    ".tests.Values.messages": {
-      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToFalse"
-    },
-    ".tests.Values.messages2": {
-      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToTrue"
-    },
     ".tests.MandatorySetAdditionalPropertiesToFalse": {
       "properties": {
         "val1": {
@@ -75,6 +53,28 @@
         "type": "integer"
       },
       "type": "array"
+    },
+    ".tests.Values": {
+      "properties": {
+        "messages": {
+          "$ref": "#/$defs/.tests.Values.messages"
+        },
+        "messages2": {
+          "$ref": "#/$defs/.tests.Values.messages2"
+        }
+      },
+      "additionalProperties": {},
+      "type": "object",
+      "required": [
+        "messages",
+        "messages2"
+      ]
+    },
+    ".tests.Values.messages": {
+      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToFalse"
+    },
+    ".tests.Values.messages2": {
+      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToTrue"
     }
   },
   "type": "object"

--- a/testdata/cases/plugin-additional-properties-default-false/test.schema.json
+++ b/testdata/cases/plugin-additional-properties-default-false/test.schema.json
@@ -2,30 +2,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$ref": "#/$defs/.tests.Values",
   "$defs": {
-    ".tests.Values": {
-      "properties": {
-        "messages": {
-          "$ref": "#/$defs/.tests.Values.messages"
-        },
-        "messages2": {
-          "$ref": "#/$defs/.tests.Values.messages2"
-        }
-      },
-      "additionalProperties": {
-        "not": {}
-      },
-      "type": "object",
-      "required": [
-        "messages",
-        "messages2"
-      ]
-    },
-    ".tests.Values.messages": {
-      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToFalse"
-    },
-    ".tests.Values.messages2": {
-      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToTrue"
-    },
     ".tests.MandatorySetAdditionalPropertiesToFalse": {
       "properties": {
         "val1": {
@@ -79,6 +55,30 @@
         "type": "integer"
       },
       "type": "array"
+    },
+    ".tests.Values": {
+      "properties": {
+        "messages": {
+          "$ref": "#/$defs/.tests.Values.messages"
+        },
+        "messages2": {
+          "$ref": "#/$defs/.tests.Values.messages2"
+        }
+      },
+      "additionalProperties": {
+        "not": {}
+      },
+      "type": "object",
+      "required": [
+        "messages",
+        "messages2"
+      ]
+    },
+    ".tests.Values.messages": {
+      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToFalse"
+    },
+    ".tests.Values.messages2": {
+      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToTrue"
     }
   },
   "type": "object"

--- a/testdata/cases/plugin-additional-properties-default-true/test.schema.json
+++ b/testdata/cases/plugin-additional-properties-default-true/test.schema.json
@@ -2,28 +2,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$ref": "#/$defs/.tests.Values",
   "$defs": {
-    ".tests.Values": {
-      "properties": {
-        "messages": {
-          "$ref": "#/$defs/.tests.Values.messages"
-        },
-        "messages2": {
-          "$ref": "#/$defs/.tests.Values.messages2"
-        }
-      },
-      "additionalProperties": {},
-      "type": "object",
-      "required": [
-        "messages",
-        "messages2"
-      ]
-    },
-    ".tests.Values.messages": {
-      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToFalse"
-    },
-    ".tests.Values.messages2": {
-      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToTrue"
-    },
     ".tests.MandatorySetAdditionalPropertiesToFalse": {
       "properties": {
         "val1": {
@@ -77,6 +55,28 @@
         "type": "integer"
       },
       "type": "array"
+    },
+    ".tests.Values": {
+      "properties": {
+        "messages": {
+          "$ref": "#/$defs/.tests.Values.messages"
+        },
+        "messages2": {
+          "$ref": "#/$defs/.tests.Values.messages2"
+        }
+      },
+      "additionalProperties": {},
+      "type": "object",
+      "required": [
+        "messages",
+        "messages2"
+      ]
+    },
+    ".tests.Values.messages": {
+      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToFalse"
+    },
+    ".tests.Values.messages2": {
+      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToTrue"
     }
   },
   "type": "object"

--- a/testdata/cases/plugin-additional-properties-do-nothing/test.schema.json
+++ b/testdata/cases/plugin-additional-properties-do-nothing/test.schema.json
@@ -2,27 +2,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$ref": "#/$defs/.tests.Values",
   "$defs": {
-    ".tests.Values": {
-      "properties": {
-        "messages": {
-          "$ref": "#/$defs/.tests.Values.messages"
-        },
-        "messages2": {
-          "$ref": "#/$defs/.tests.Values.messages2"
-        }
-      },
-      "type": "object",
-      "required": [
-        "messages",
-        "messages2"
-      ]
-    },
-    ".tests.Values.messages": {
-      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToFalse"
-    },
-    ".tests.Values.messages2": {
-      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToTrue"
-    },
     ".tests.MandatorySetAdditionalPropertiesToFalse": {
       "properties": {
         "val1": {
@@ -76,6 +55,27 @@
         "type": "integer"
       },
       "type": "array"
+    },
+    ".tests.Values": {
+      "properties": {
+        "messages": {
+          "$ref": "#/$defs/.tests.Values.messages"
+        },
+        "messages2": {
+          "$ref": "#/$defs/.tests.Values.messages2"
+        }
+      },
+      "type": "object",
+      "required": [
+        "messages",
+        "messages2"
+      ]
+    },
+    ".tests.Values.messages": {
+      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToFalse"
+    },
+    ".tests.Values.messages2": {
+      "$ref": "#/$defs/.tests.MandatorySetAdditionalPropertiesToTrue"
     }
   },
   "type": "object"

--- a/testdata/cases/plugin-consist-output/moreprotos/config.proto
+++ b/testdata/cases/plugin-consist-output/moreprotos/config.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package cloud.ilsa.config;
+
+option go_package = "src.hexon.nl/ilsa/proto/pb";
+
+import "moreprotos/keywords.proto";
+
+message SearchableField {
+	repeated cloud.ilsa.internal.KeywordDefinition.KeywordSet keyword_sets = 10;
+}
+
+message InstanceConfig {
+	repeated SearchableField searchable_fields = 6;
+
+	message Subset {
+		string id = 1;
+	}
+}

--- a/testdata/cases/plugin-consist-output/moreprotos/keywords.proto
+++ b/testdata/cases/plugin-consist-output/moreprotos/keywords.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package cloud.ilsa.internal;
+
+option go_package = "src.hexon.nl/ilsa/proto/pb";
+
+message KeywordDefinitionList {
+	repeated KeywordDefinition entries = 1;
+}
+
+message KeywordDefinition {
+	enum KeywordSet {
+		UNKNOWN = 0;
+	}
+}

--- a/testdata/cases/plugin-consist-output/test.proto
+++ b/testdata/cases/plugin-consist-output/test.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package tests;
+
+import "jsonschema.proto";
+import "moreprotos/config.proto";
+
+option go_package = "github.com/pubg/fooo";
+
+option (pubg.jsonschema.file) = {entrypoint_message: "Wrapper"};
+
+message Wrapper {
+	cloud.ilsa.config.InstanceConfig bar = 1;
+}

--- a/testdata/cases/plugin-consist-output/test.schema.json
+++ b/testdata/cases/plugin-consist-output/test.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "#/$defs/.tests.Wrapper",
+  "$defs": {
+    ".cloud.ilsa.config.InstanceConfig": {
+      "properties": {
+        "searchableFields": {
+          "$ref": "#/$defs/.cloud.ilsa.config.InstanceConfig.searchable_fields"
+        }
+      },
+      "type": "object"
+    },
+    ".cloud.ilsa.config.InstanceConfig.searchable_fields": {
+      "items": {
+        "$ref": "#/$defs/.cloud.ilsa.config.SearchableField"
+      },
+      "type": "array"
+    },
+    ".cloud.ilsa.config.SearchableField": {
+      "properties": {
+        "keywordSets": {
+          "$ref": "#/$defs/.cloud.ilsa.config.SearchableField.keyword_sets"
+        }
+      },
+      "type": "object"
+    },
+    ".cloud.ilsa.config.SearchableField.keyword_sets": {
+      "items": {
+        "$ref": "#/$defs/.cloud.ilsa.internal.KeywordDefinition.KeywordSet"
+      },
+      "type": "array"
+    },
+    ".cloud.ilsa.internal.KeywordDefinition.KeywordSet": {
+      "type": "string",
+      "enum": [
+        "UNKNOWN"
+      ]
+    },
+    ".tests.Wrapper": {
+      "properties": {
+        "bar": {
+          "$ref": "#/$defs/.tests.Wrapper.bar"
+        }
+      },
+      "type": "object",
+      "required": [
+        "bar"
+      ]
+    },
+    ".tests.Wrapper.bar": {
+      "$ref": "#/$defs/.cloud.ilsa.config.InstanceConfig"
+    }
+  },
+  "type": "object"
+}

--- a/testdata/cases/plugin-consist-output/test.yaml
+++ b/testdata/cases/plugin-consist-output/test.yaml
@@ -1,0 +1,11 @@
+name: "plugin-consist-output"
+description: ""
+
+inputFiles: ["test.proto"]
+inputParameters: {}
+
+expectResultFiles: ["test.schema.json"]
+expectResultIsNull: false
+expectFail: false
+
+expectedBehaviorDescription: ""

--- a/testdata/cases/plugin-draft-04/test.schema.json
+++ b/testdata/cases/plugin-draft-04/test.schema.json
@@ -25,6 +25,12 @@
         "int64"
       ]
     },
+    ".tests.Values.int64": {
+      "type": "integer",
+      "maximum": 10,
+      "exclusiveMaximum": true,
+      "description": "Exclusive maximum should convert to maximum: 10 and exclusive_maximum: true"
+    },
     ".tests.Values.string1": {
       "type": "string",
       "description": "default option"
@@ -40,12 +46,6 @@
       "maxLength": 0,
       "minLength": 0,
       "description": "min/max with zero value"
-    },
-    ".tests.Values.int64": {
-      "type": "integer",
-      "maximum": 10,
-      "exclusiveMaximum": true,
-      "description": "Exclusive maximum should convert to maximum: 10 and exclusive_maximum: true"
     }
   },
   "type": "object"

--- a/testdata/cases/plugin-draft-06/test.schema.json
+++ b/testdata/cases/plugin-draft-06/test.schema.json
@@ -25,6 +25,10 @@
         "int64"
       ]
     },
+    ".tests.Values.int64": {
+      "type": "integer",
+      "exclusiveMaximum": 10
+    },
     ".tests.Values.string1": {
       "type": "string",
       "description": "default option"
@@ -40,10 +44,6 @@
       "maxLength": 0,
       "minLength": 0,
       "description": "min/max with zero value"
-    },
-    ".tests.Values.int64": {
-      "type": "integer",
-      "exclusiveMaximum": 10
     }
   },
   "type": "object"

--- a/testdata/cases/plugin-draft-07/test.schema.json
+++ b/testdata/cases/plugin-draft-07/test.schema.json
@@ -25,6 +25,10 @@
         "int64"
       ]
     },
+    ".tests.Values.int64": {
+      "type": "integer",
+      "exclusiveMaximum": 10
+    },
     ".tests.Values.string1": {
       "type": "string",
       "description": "default option"
@@ -40,10 +44,6 @@
       "maxLength": 0,
       "minLength": 0,
       "description": "min/max with zero value"
-    },
-    ".tests.Values.int64": {
-      "type": "integer",
-      "exclusiveMaximum": 10
     }
   },
   "type": "object"

--- a/testdata/cases/plugin-draft-201909/test.schema.json
+++ b/testdata/cases/plugin-draft-201909/test.schema.json
@@ -25,6 +25,10 @@
         "int64"
       ]
     },
+    ".tests.Values.int64": {
+      "type": "integer",
+      "exclusiveMaximum": 10
+    },
     ".tests.Values.string1": {
       "type": "string",
       "description": "default option"
@@ -40,10 +44,6 @@
       "maxLength": 0,
       "minLength": 0,
       "description": "min/max with zero value"
-    },
-    ".tests.Values.int64": {
-      "type": "integer",
-      "exclusiveMaximum": 10
     }
   },
   "type": "object"

--- a/testdata/cases/plugin-draft-202012/test.schema.json
+++ b/testdata/cases/plugin-draft-202012/test.schema.json
@@ -25,6 +25,10 @@
         "int64"
       ]
     },
+    ".tests.Values.int64": {
+      "type": "integer",
+      "exclusiveMaximum": 10
+    },
     ".tests.Values.string1": {
       "type": "string",
       "description": "default option"
@@ -40,10 +44,6 @@
       "maxLength": 0,
       "minLength": 0,
       "description": "min/max with zero value"
-    },
-    ".tests.Values.int64": {
-      "type": "integer",
-      "exclusiveMaximum": 10
     }
   },
   "type": "object"

--- a/testdata/cases/plugin-entrypoint/test.schema.json
+++ b/testdata/cases/plugin-entrypoint/test.schema.json
@@ -34,15 +34,15 @@
       "exclusiveMaximum": 20,
       "exclusiveMinimum": 10
     },
-    ".tests.Values2.string": {
-      "type": "string",
-      "pattern": "^[a-zA-Z0-9]+$"
-    },
     ".tests.Values2.map": {
       "additionalProperties": {
         "type": "string"
       },
       "type": "object"
+    },
+    ".tests.Values2.string": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]+$"
     }
   },
   "type": "object"

--- a/testdata/cases/plugin-preserve-field-name-false/test.schema.json
+++ b/testdata/cases/plugin-preserve-field-name-false/test.schema.json
@@ -25,16 +25,16 @@
         "abc123"
       ]
     },
-    ".tests.Values.foo_bar_baz": {
-      "type": "string"
-    },
-    ".tests.Values.implicit_camel_case": {
+    ".tests.Values.arbitrary_value": {
       "type": "string"
     },
     ".tests.Values.explicit_snake_case": {
       "type": "string"
     },
-    ".tests.Values.arbitrary_value": {
+    ".tests.Values.foo_bar_baz": {
+      "type": "string"
+    },
+    ".tests.Values.implicit_camel_case": {
       "type": "string"
     }
   },

--- a/testdata/cases/plugin-preserve-field-name-true/test.schema.json
+++ b/testdata/cases/plugin-preserve-field-name-true/test.schema.json
@@ -25,16 +25,16 @@
         "arbitrary_value"
       ]
     },
-    ".tests.Values.foo_bar_baz": {
-      "type": "string"
-    },
-    ".tests.Values.implicit_camel_case": {
+    ".tests.Values.arbitrary_value": {
       "type": "string"
     },
     ".tests.Values.explicit_snake_case": {
       "type": "string"
     },
-    ".tests.Values.arbitrary_value": {
+    ".tests.Values.foo_bar_baz": {
+      "type": "string"
+    },
+    ".tests.Values.implicit_camel_case": {
       "type": "string"
     }
   },

--- a/testdata/cases/proto-circular-dependent/test.schema.json
+++ b/testdata/cases/proto-circular-dependent/test.schema.json
@@ -2,20 +2,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$ref": "#/$defs/.tests.Values",
   "$defs": {
-    ".tests.Values": {
-      "properties": {
-        "entry": {
-          "$ref": "#/$defs/.tests.Values.entry"
-        }
-      },
-      "type": "object",
-      "required": [
-        "entry"
-      ]
-    },
-    ".tests.Values.entry": {
-      "$ref": "#/$defs/.tests.SelfReference"
-    },
     ".tests.SelfReference": {
       "properties": {
         "self": {
@@ -29,6 +15,20 @@
       "description": "message CircularDependentTwoDepth {\n  CircularDependentTwoDepth0 child = 1;\n}\n\nmessage CircularDependentTwoDepth0 {\n  CircularDependentTwoDepth parent = 1;\n}"
     },
     ".tests.SelfReference.self": {
+      "$ref": "#/$defs/.tests.SelfReference"
+    },
+    ".tests.Values": {
+      "properties": {
+        "entry": {
+          "$ref": "#/$defs/.tests.Values.entry"
+        }
+      },
+      "type": "object",
+      "required": [
+        "entry"
+      ]
+    },
+    ".tests.Values.entry": {
       "$ref": "#/$defs/.tests.SelfReference"
     }
   },

--- a/testdata/cases/proto-enum/test.schema.json
+++ b/testdata/cases/proto-enum/test.schema.json
@@ -9,20 +9,6 @@
         "FOODefault1"
       ]
     },
-    ".tests.MapToNumber": {
-      "type": "number",
-      "enum": [
-        0,
-        1
-      ]
-    },
-    ".tests.MapToString": {
-      "type": "string",
-      "enum": [
-        "FOOMapToString0",
-        "FOOMapToString1"
-      ]
-    },
     ".tests.MapToCustom": {
       "type": "string",
       "enum": [
@@ -36,6 +22,20 @@
         "foo",
         123,
         "FOOMapToCustomIncomplete2"
+      ]
+    },
+    ".tests.MapToNumber": {
+      "type": "number",
+      "enum": [
+        0,
+        1
+      ]
+    },
+    ".tests.MapToString": {
+      "type": "string",
+      "enum": [
+        "FOOMapToString0",
+        "FOOMapToString1"
       ]
     },
     ".tests.Values": {
@@ -79,11 +79,8 @@
     ".tests.Values.default": {
       "$ref": "#/$defs/.tests.Default"
     },
-    ".tests.Values.map_to_number": {
-      "$ref": "#/$defs/.tests.MapToNumber"
-    },
-    ".tests.Values.map_to_string": {
-      "$ref": "#/$defs/.tests.MapToString"
+    ".tests.Values.inline_enum": {
+      "$ref": "#/$defs/.tests.Values.InlineEnum"
     },
     ".tests.Values.map_to_custom": {
       "$ref": "#/$defs/.tests.MapToCustom"
@@ -91,8 +88,11 @@
     ".tests.Values.map_to_custom_incomplete": {
       "$ref": "#/$defs/.tests.MapToCustomIncomplete"
     },
-    ".tests.Values.inline_enum": {
-      "$ref": "#/$defs/.tests.Values.InlineEnum"
+    ".tests.Values.map_to_number": {
+      "$ref": "#/$defs/.tests.MapToNumber"
+    },
+    ".tests.Values.map_to_string": {
+      "$ref": "#/$defs/.tests.MapToString"
     }
   },
   "type": "object"

--- a/testdata/cases/proto-map/test.schema.json
+++ b/testdata/cases/proto-map/test.schema.json
@@ -11,6 +11,20 @@
         "THREE"
       ]
     },
+    ".tests.Nested": {
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/.tests.Nested.value"
+        }
+      },
+      "type": "object",
+      "required": [
+        "value"
+      ]
+    },
+    ".tests.Nested.value": {
+      "type": "string"
+    },
     ".tests.Values": {
       "properties": {
         "basicMap": {
@@ -43,31 +57,9 @@
       },
       "type": "object"
     },
-    ".tests.Values.int_map": {
-      "additionalProperties": {},
-      "type": "integer"
-    },
-    ".tests.Values.float_map": {
-      "additionalProperties": {
-        "type": "number"
-      },
-      "type": "object"
-    },
     ".tests.Values.bool_map": {
       "additionalProperties": {
         "type": "boolean"
-      },
-      "type": "object"
-    },
-    ".tests.Values.string_map": {
-      "additionalProperties": {
-        "type": "string"
-      },
-      "type": "object"
-    },
-    ".tests.Values.nested_map": {
-      "additionalProperties": {
-        "$ref": "#/$defs/.tests.Nested"
       },
       "type": "object"
     },
@@ -77,19 +69,27 @@
       },
       "type": "object"
     },
-    ".tests.Nested": {
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/.tests.Nested.value"
-        }
+    ".tests.Values.float_map": {
+      "additionalProperties": {
+        "type": "number"
       },
-      "type": "object",
-      "required": [
-        "value"
-      ]
+      "type": "object"
     },
-    ".tests.Nested.value": {
-      "type": "string"
+    ".tests.Values.int_map": {
+      "additionalProperties": {},
+      "type": "integer"
+    },
+    ".tests.Values.nested_map": {
+      "additionalProperties": {
+        "$ref": "#/$defs/.tests.Nested"
+      },
+      "type": "object"
+    },
+    ".tests.Values.string_map": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
     }
   },
   "type": "object"

--- a/testdata/cases/proto-oneof-multiple/test.schema.json
+++ b/testdata/cases/proto-oneof-multiple/test.schema.json
@@ -131,31 +131,31 @@
         "description"
       ]
     },
-    ".samples.Values.value": {
-      "type": "string"
-    },
     ".samples.Values.count": {
       "type": "integer"
     },
-    ".samples.Values.string_value": {
+    ".samples.Values.description": {
       "type": "string"
     },
     ".samples.Values.int_value": {
       "type": "integer"
     },
+    ".samples.Values.string_value": {
+      "type": "string"
+    },
     ".samples.Values.timestamp": {
       "type": "integer"
     },
-    ".samples.Values.unit": {
-      "type": "string"
-    },
-    ".samples.Values.description": {
+    ".samples.Values.type_id": {
       "type": "string"
     },
     ".samples.Values.type_name": {
       "type": "string"
     },
-    ".samples.Values.type_id": {
+    ".samples.Values.unit": {
+      "type": "string"
+    },
+    ".samples.Values.value": {
       "type": "string"
     }
   },

--- a/testdata/cases/proto-oneof-single/test.schema.json
+++ b/testdata/cases/proto-oneof-single/test.schema.json
@@ -109,23 +109,23 @@
         "count"
       ]
     },
-    ".samples.Values.value": {
-      "type": "string"
+    ".samples.Values.bool_value": {
+      "type": "boolean"
     },
     ".samples.Values.count": {
+      "type": "integer"
+    },
+    ".samples.Values.double_value": {
+      "type": "number"
+    },
+    ".samples.Values.int_value": {
       "type": "integer"
     },
     ".samples.Values.string_value": {
       "type": "string"
     },
-    ".samples.Values.int_value": {
-      "type": "integer"
-    },
-    ".samples.Values.bool_value": {
-      "type": "boolean"
-    },
-    ".samples.Values.double_value": {
-      "type": "number"
+    ".samples.Values.value": {
+      "type": "string"
     }
   },
   "type": "object"

--- a/testdata/cases/proto-optional/test.schema.json
+++ b/testdata/cases/proto-optional/test.schema.json
@@ -11,6 +11,20 @@
         "THREE"
       ]
     },
+    ".tests.Nested": {
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/.tests.Nested.value"
+        }
+      },
+      "type": "object",
+      "required": [
+        "value"
+      ]
+    },
+    ".tests.Nested.value": {
+      "type": "string"
+    },
     ".tests.Values": {
       "allOf": [
         {
@@ -186,45 +200,31 @@
         "enumValue"
       ]
     },
-    ".tests.Values.string_value": {
-      "type": "string"
+    ".tests.Values.enum_value": {
+      "$ref": "#/$defs/.tests.Enum"
     },
     ".tests.Values.int32_value": {
+      "type": "integer"
+    },
+    ".tests.Values.int32_value2": {
       "type": "integer"
     },
     ".tests.Values.int64_value": {
       "type": "integer"
     },
-    ".tests.Values.string_value2": {
-      "type": "string"
-    },
-    ".tests.Values.int32_value2": {
-      "type": "integer"
-    },
     ".tests.Values.nested_value": {
-      "$ref": "#/$defs/.tests.Nested"
-    },
-    ".tests.Values.enum_value": {
-      "$ref": "#/$defs/.tests.Enum"
-    },
-    ".tests.Values.optional_nested_value": {
       "$ref": "#/$defs/.tests.Nested"
     },
     ".tests.Values.optional_enum_value": {
       "$ref": "#/$defs/.tests.Enum"
     },
-    ".tests.Nested": {
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/.tests.Nested.value"
-        }
-      },
-      "type": "object",
-      "required": [
-        "value"
-      ]
+    ".tests.Values.optional_nested_value": {
+      "$ref": "#/$defs/.tests.Nested"
     },
-    ".tests.Nested.value": {
+    ".tests.Values.string_value": {
+      "type": "string"
+    },
+    ".tests.Values.string_value2": {
       "type": "string"
     }
   },

--- a/testdata/cases/proto-version-syntax-proto2/test.schema.json
+++ b/testdata/cases/proto-version-syntax-proto2/test.schema.json
@@ -11,6 +11,20 @@
         "THREE"
       ]
     },
+    ".tests.Nested": {
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/.tests.Nested.value"
+        }
+      },
+      "type": "object",
+      "required": [
+        "value"
+      ]
+    },
+    ".tests.Nested.value": {
+      "type": "string"
+    },
     ".tests.Values": {
       "properties": {
         "stringValue": {
@@ -84,45 +98,31 @@
         "enumValue"
       ]
     },
-    ".tests.Values.string_value": {
-      "type": "string"
+    ".tests.Values.enum_value": {
+      "$ref": "#/$defs/.tests.Enum"
     },
     ".tests.Values.int32_value": {
+      "type": "integer"
+    },
+    ".tests.Values.int32_value2": {
       "type": "integer"
     },
     ".tests.Values.int64_value": {
       "type": "integer"
     },
-    ".tests.Values.string_value2": {
-      "type": "string"
-    },
-    ".tests.Values.int32_value2": {
-      "type": "integer"
-    },
     ".tests.Values.nested_value": {
-      "$ref": "#/$defs/.tests.Nested"
-    },
-    ".tests.Values.enum_value": {
-      "$ref": "#/$defs/.tests.Enum"
-    },
-    ".tests.Values.optional_nested_value": {
       "$ref": "#/$defs/.tests.Nested"
     },
     ".tests.Values.optional_enum_value": {
       "$ref": "#/$defs/.tests.Enum"
     },
-    ".tests.Nested": {
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/.tests.Nested.value"
-        }
-      },
-      "type": "object",
-      "required": [
-        "value"
-      ]
+    ".tests.Values.optional_nested_value": {
+      "$ref": "#/$defs/.tests.Nested"
     },
-    ".tests.Nested.value": {
+    ".tests.Values.string_value": {
+      "type": "string"
+    },
+    ".tests.Values.string_value2": {
       "type": "string"
     }
   },

--- a/testdata/cases/proto-version-syntax-proto3/test.schema.json
+++ b/testdata/cases/proto-version-syntax-proto3/test.schema.json
@@ -11,6 +11,20 @@
         "THREE"
       ]
     },
+    ".tests.Nested": {
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/.tests.Nested.value"
+        }
+      },
+      "type": "object",
+      "required": [
+        "value"
+      ]
+    },
+    ".tests.Nested.value": {
+      "type": "string"
+    },
     ".tests.Values": {
       "allOf": [
         {
@@ -186,45 +200,31 @@
         "enumValue"
       ]
     },
-    ".tests.Values.string_value": {
-      "type": "string"
+    ".tests.Values.enum_value": {
+      "$ref": "#/$defs/.tests.Enum"
     },
     ".tests.Values.int32_value": {
+      "type": "integer"
+    },
+    ".tests.Values.int32_value2": {
       "type": "integer"
     },
     ".tests.Values.int64_value": {
       "type": "integer"
     },
-    ".tests.Values.string_value2": {
-      "type": "string"
-    },
-    ".tests.Values.int32_value2": {
-      "type": "integer"
-    },
     ".tests.Values.nested_value": {
-      "$ref": "#/$defs/.tests.Nested"
-    },
-    ".tests.Values.enum_value": {
-      "$ref": "#/$defs/.tests.Enum"
-    },
-    ".tests.Values.optional_nested_value": {
       "$ref": "#/$defs/.tests.Nested"
     },
     ".tests.Values.optional_enum_value": {
       "$ref": "#/$defs/.tests.Enum"
     },
-    ".tests.Nested": {
-      "properties": {
-        "value": {
-          "$ref": "#/$defs/.tests.Nested.value"
-        }
-      },
-      "type": "object",
-      "required": [
-        "value"
-      ]
+    ".tests.Values.optional_nested_value": {
+      "$ref": "#/$defs/.tests.Nested"
     },
-    ".tests.Nested.value": {
+    ".tests.Values.string_value": {
+      "type": "string"
+    },
+    ".tests.Values.string_value2": {
       "type": "string"
     }
   },

--- a/testdata/cases/wellknown-k8s/test.proto
+++ b/testdata/cases/wellknown-k8s/test.proto
@@ -4,6 +4,8 @@ package tests;
 
 import "jsonschema.proto";
 
+option go_package = "github.com/pubg/fooo";
+
 option (pubg.jsonschema.file) = {entrypoint_message: "Values"};
 
 import "k8s.io/apimachinery/pkg/util/intstr/generated.proto";


### PR DESCRIPTION
Consistent Plugin Output
- Previously, due to an issue with the visiting algorithm in the protoc-gen-star library, outputs were mostly consistent but occasionally had ordering differences.
- Added schema key–based sorting during schema generation, ensuring that the output is now always consistent.

close #17 